### PR TITLE
Remove copy_memory and slice_bytes feature flag.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,12 @@
 //!
 //! [1]: https://tools.ietf.org/html/rfc5869
 
-#![feature(slice_bytes)]
-
 extern crate sodiumoxide;
 
 use sodiumoxide::crypto::auth::hmacsha256::{KEYBYTES};
 use sodiumoxide::crypto::auth::hmacsha256::{Tag, Key, authenticate};
 use sodiumoxide::crypto::hash::sha256::{Digest, hash};
-use std::slice::bytes::copy_memory;
+use std::io::Write;
 use std::vec::Vec;
 
 pub const HASH_LEN: usize = 32;
@@ -73,7 +71,7 @@ fn mk_salt(input: &[u8]) -> [u8; KEYBYTES] {
         d
     } else {
         let mut b = [0; KEYBYTES];
-        copy_memory(input, &mut b);
+        b.as_mut().write_all(&input).unwrap();
         b
     }
 }


### PR DESCRIPTION
- copy_memory was deprecated and is already removed in the current nightly.
- The slice_bytes feature flag is now redundant.

This allows `hkdf` to build with the current stable, beta and nightly channels.
